### PR TITLE
fix(job): force-flush telemetry so job root span is captured

### DIFF
--- a/internal/cmd/internal/job/commits/cmd.go
+++ b/internal/cmd/internal/job/commits/cmd.go
@@ -52,7 +52,33 @@ func Root() *cobra.Command {
 				tracer := m.TracerProvider().Tracer("command")
 
 				ctx, span := tracer.Start(ctx, "job.commits")
-				defer span.End()
+				defer func() {
+					// End the root span first, then force-flush telemetry.
+					//
+					// This is a short-lived one-shot job: the batch span
+					// processor exports asynchronously on a timer, so without an
+					// explicit flush the root span and its children may never be
+					// exported before the process exits. Use a detached context
+					// so the flush is not affected by shutdown cancellation.
+					span.End()
+
+					flushCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+					defer cancel()
+					if tp, ok := m.TracerProvider().(interface {
+						ForceFlush(context.Context) error
+					}); ok {
+						if err := tp.ForceFlush(flushCtx); err != nil {
+							logger.Warn("Flush traces", zap.Error(err))
+						}
+					}
+					if mp, ok := m.MeterProvider().(interface {
+						ForceFlush(context.Context) error
+					}); ok {
+						if err := mp.ForceFlush(flushCtx); err != nil {
+							logger.Warn("Flush metrics", zap.Error(err))
+						}
+					}
+				}()
 
 				httpTransport := otelhttp.NewTransport(http.DefaultTransport,
 					otelhttp.WithTracerProvider(m.TracerProvider()),


### PR DESCRIPTION
## Summary
Fixes #186 — the root span of the periodic `job commits` command (and its children) was not being captured.

## Root cause
The `commits` job is a short-lived, one-shot command. The OpenTelemetry **batch span processor exports spans asynchronously on a timer**, so for a job that completes within a single batch interval, the root `job.commits` span and its children can be lost if the process exits before an export cycle runs — even though shutdown is graceful.

## Fix
After the work completes, end the root span explicitly and **force-flush** the tracer and meter providers before returning. A detached context (`context.WithoutCancel` + timeout) is used so the flush is not aborted by shutdown cancellation.

## Testing
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)